### PR TITLE
Update Launch on qBraid link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can run these notebooks in the cloud or on your local machine.
 
 🚀 Click on the "Launch on qBraid" button below to access the notebooks in your qBraid account. 
 
-[<img src="https://qbraid-static.s3.amazonaws.com/logos/Launch_on_qBraid_white.png" width="150">](https://account.qbraid.com?gitHubUrl=https://github.com/PennyLaneAI/pennylane-demo-notebooks.git)
+[<img src="https://qbraid-static.s3.amazonaws.com/logos/Launch_on_qBraid_white.png" width="150">](https://account.qbraid.com/explore/projects/pennylane-qsvt-demo)
 
 *(Note: Give it a couple of minutes for qBraid to clone the repository and set up your PennyLane environment.)*
 


### PR DESCRIPTION
Update launch on qBraid link to point to explore page listing.

From there, the users can click the Launch on Lab button, which will git clone this repository and install the PennyLane (v0.45.0) environment.

